### PR TITLE
DualCore example: use `target-set` (prepared for cmsis-debugger)

### DIFF
--- a/examples/M55_HP_HE/DualCore/DualCore.csolution.yml
+++ b/examples/M55_HP_HE/DualCore/DualCore.csolution.yml
@@ -1,5 +1,5 @@
 solution:
-  created-for: CMSIS-Toolbox@2.8.0
+  created-for: CMSIS-Toolbox@2.9.0
   cdefault:
 
   select-compiler:
@@ -21,6 +21,14 @@ solution:
     - type: Alif-AppKit-E7
       board: Alif Semiconductor::AppKit-E7
       device: Alif Semiconductor::AE722F80F55D5LS
+      target-set:
+        - set:
+          debugger:
+            name: JLink Server
+            start-pname: M55_HP
+          images:
+            - project-context: M55_HP.Debug
+            - project-context: M55_HE.Debug
 
   build-types:
     - type: Debug

--- a/examples/M55_HP_HE/DualCore/M55_HE/M55_HE.cproject.yml
+++ b/examples/M55_HP_HE/DualCore/M55_HE/M55_HE.cproject.yml
@@ -38,3 +38,5 @@ project:
     type:
       - elf
       - bin
+      - hex
+      - map

--- a/examples/M55_HP_HE/DualCore/M55_HP/M55_HP.cproject.yml
+++ b/examples/M55_HP_HE/DualCore/M55_HP/M55_HP.cproject.yml
@@ -47,3 +47,5 @@ project:
     type:
       - elf
       - bin
+      - hex
+      - map

--- a/examples/M55_HP_HE/DualCore/cdefault.yml
+++ b/examples/M55_HP_HE/DualCore/cdefault.yml
@@ -3,6 +3,7 @@ default:
   misc:
     - for-compiler: AC6
       C-CPP:
+        - -gdwarf-5
         - -Wno-macro-redefined
         - -Wno-pragma-pack
         - -Wno-parentheses-equality
@@ -11,6 +12,7 @@ default:
         - -std=gnu11
       ASM:
         - -masm=auto
+        - -gdwarf-5
       Link:
         - --entry=Reset_Handler
         - --info summarysizes


### PR DESCRIPTION
- requires latest toolbox and VS Code extensions